### PR TITLE
Fix method 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibantools-germany",
-  "version": "1.2200.0",
+  "version": "1.2200.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ibantools-germany",
-      "version": "1.2200.0",
+      "version": "1.2200.2",
       "license": "AGPL",
       "devDependencies": {
         "@types/jest": "^29.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibantools-germany",
-  "version": "1.2200.0",
+  "version": "1.2200.2",
   "description": "IBAN Validator and Generator for German Bank Accounts",
   "author": "Markus Baumer <markus@baumer.dev>",
   "repository": "https://github.com/baumerdev/ibantools-germany",

--- a/src/__tests__/lib/helper.spec.ts
+++ b/src/__tests__/lib/helper.spec.ts
@@ -166,11 +166,14 @@ describe("weightDigitsRTL", () => {
 
 describe("moduloDifference", () => {
   it("returns 0 for minuend 0 and value 0", () => {
-    expect(moduloDifference(0, 1, 0)).toEqual(0);
+    expect(moduloDifference(0, 1, 0)).toEqual({ difference: 0, remainder: 0 });
   });
 
   it("returns 9 for divisor 10, minuend 11 and value 12", () => {
-    expect(moduloDifference(12, 10, 11)).toEqual(9);
+    expect(moduloDifference(12, 10, 11)).toEqual({
+      difference: 9,
+      remainder: 2,
+    });
   });
 });
 

--- a/src/__tests__/lib/methods/method16.spec.ts
+++ b/src/__tests__/lib/methods/method16.spec.ts
@@ -30,7 +30,9 @@ describe("method 16", () => {
   it("confirms 1234567841 is valid (default, remainder 1)", () => {
     expect(method16("1234567841")).toEqual(Result.VALID);
   });
-
+  it("confirms 1234568499 is valid (special, remainder 1)", () => {
+    expect(method16("1234568499")).toEqual(Result.VALID);
+  });
   // Check for invalid result
   it("confirms 1135567895 is invalid", () => {
     expect(method16("1135567895")).toEqual(Result.INVALID);

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -127,7 +127,7 @@ export const weightDigitsRTL = (
 
 /**
  * Calculates the modulo (remainder of division) and subtracts it from
- * the minuend.
+ * the minuend, returns difference and remainder.
  *
  * Example: Value 12 with divisor 10 and minuend 11 will return 9 (remainder of 12/10 = 2; 11-2 = 9)
  */
@@ -135,7 +135,10 @@ export const moduloDifference = (
   value: number,
   divisor: number,
   minuend: number
-): number => minuend - (value % divisor);
+): { difference: number; remainder: number } => {
+  const remainder = value % divisor;
+  return { difference: minuend - remainder, remainder };
+};
 
 /**
  * Get the difference to next half decade (5, 15, 25...).

--- a/src/lib/methods/method02.ts
+++ b/src/lib/methods/method02.ts
@@ -30,7 +30,7 @@ export const method02Core = (number: string, weights: number[]): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, weights);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   if (calculatedCheckDigit === 11) {
     if (givenCheckDigit === 0) {

--- a/src/lib/methods/method06.ts
+++ b/src/lib/methods/method06.ts
@@ -28,15 +28,23 @@ export const method06CheckDigit = (
   number: string,
   weights: number[],
   modulo = 11
-): { calculatedCheckDigit: number; givenCheckDigit: number } => {
+): {
+  calculatedCheckDigit: number;
+  diffRemainder: number;
+  givenCheckDigit: number;
+} => {
   const digits = getDigits(number);
   const givenCheckDigit = digits.pop() as number; // Check digit is last digit
 
   const weightedDigits = weightDigitsRTL(digits, weights);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, modulo, modulo);
+  const { difference: calculatedCheckDigit, remainder } = moduloDifference(
+    sum,
+    modulo,
+    modulo
+  );
 
-  return { calculatedCheckDigit, givenCheckDigit };
+  return { calculatedCheckDigit, diffRemainder: remainder, givenCheckDigit };
 };
 
 export const method06Result = (

--- a/src/lib/methods/method16.ts
+++ b/src/lib/methods/method16.ts
@@ -21,12 +21,10 @@ import { Result } from "../types";
 import { method06CheckDigit, method06Result } from "./method06";
 
 export default (number: string): Result => {
-  const { calculatedCheckDigit, givenCheckDigit } = method06CheckDigit(
-    number,
-    [2, 3, 4, 5, 6, 7, 2, 3, 4]
-  );
+  const { calculatedCheckDigit, givenCheckDigit, diffRemainder } =
+    method06CheckDigit(number, [2, 3, 4, 5, 6, 7, 2, 3, 4]);
 
-  if (calculatedCheckDigit === 1 && number.slice(-2, -1) === number.slice(-1)) {
+  if (diffRemainder === 1 && number.slice(-2, -1) === number.slice(-1)) {
     return Result.VALID;
   }
 

--- a/src/lib/methods/method17.ts
+++ b/src/lib/methods/method17.ts
@@ -35,7 +35,11 @@ export default (number: string): Result => {
   const weightedDigits = weightDigits(digits, [1, 2, 1, 2, 1, 2]);
   const crossSumDigits = calculateCrossSums(weightedDigits);
   const sumMinus1 = calculateSum(crossSumDigits) - 1;
-  const calculatedCheckDigit = moduloDifference(sumMinus1, 11, 10);
+  const { difference: calculatedCheckDigit } = moduloDifference(
+    sumMinus1,
+    11,
+    10
+  );
 
   if (calculatedCheckDigit === 10 && givenCheckDigit === 0) {
     return Result.VALID;

--- a/src/lib/methods/method25.ts
+++ b/src/lib/methods/method25.ts
@@ -36,7 +36,7 @@ export default (number: string): Result => {
   );
 
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   if (calculatedCheckDigit === 11) {
     if (givenCheckDigit === 0) {

--- a/src/lib/methods/method32.ts
+++ b/src/lib/methods/method32.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method33.ts
+++ b/src/lib/methods/method33.ts
@@ -39,7 +39,11 @@ export const method33Core = (
   const weightedDigits = weightDigitsRTL(digits, weights);
   const sum = calculateSum(weightedDigits);
 
-  const calculatedCheckDigit = moduloDifference(sum, modulo, modulo);
+  const { difference: calculatedCheckDigit } = moduloDifference(
+    sum,
+    modulo,
+    modulo
+  );
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method36.ts
+++ b/src/lib/methods/method36.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 4, 8, 5]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method37.ts
+++ b/src/lib/methods/method37.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 4, 8, 5, 10]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method38.ts
+++ b/src/lib/methods/method38.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 4, 8, 5, 10, 9]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method39.ts
+++ b/src/lib/methods/method39.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 4, 8, 5, 10, 9, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method40.ts
+++ b/src/lib/methods/method40.ts
@@ -32,7 +32,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 4, 8, 5, 10, 9, 7, 3, 6]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method42.ts
+++ b/src/lib/methods/method42.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7, 8, 9]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method43.ts
+++ b/src/lib/methods/method43.ts
@@ -30,7 +30,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 10, 10);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 10, 10);
 
   if (calculatedCheckDigit === 10 && givenCheckDigit === 0) {
     return Result.VALID;

--- a/src/lib/methods/method46.ts
+++ b/src/lib/methods/method46.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method47.ts
+++ b/src/lib/methods/method47.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method48.ts
+++ b/src/lib/methods/method48.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method50.ts
+++ b/src/lib/methods/method50.ts
@@ -34,7 +34,7 @@ const method50Core = (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method51.ts
+++ b/src/lib/methods/method51.ts
@@ -35,7 +35,7 @@ const method51aCore = (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };
@@ -55,7 +55,7 @@ const method51dVariation1 = (number: string): Result => {
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7, 8]);
   const sum = calculateSum(weightedDigits);
 
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };
@@ -67,7 +67,7 @@ const method51dVariation2 = (number: string): Result => {
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7, 8, 9, 10]);
   const sum = calculateSum(weightedDigits);
 
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method56.ts
+++ b/src/lib/methods/method56.ts
@@ -32,7 +32,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7, 2, 3, 4]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   if (calculatedCheckDigit === 10) {
     if (paddedNumber.slice(0, 1) === "9" && givenCheckDigit === 7) {

--- a/src/lib/methods/method64.ts
+++ b/src/lib/methods/method64.ts
@@ -34,7 +34,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigits(digits, [9, 10, 5, 8, 4, 2]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method66.ts
+++ b/src/lib/methods/method66.ts
@@ -45,7 +45,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(validateDigits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method71.ts
+++ b/src/lib/methods/method71.ts
@@ -33,7 +33,7 @@ export default (number: string): Result => {
 
   const weightedDigits = weightDigits(digits, [6, 5, 4, 3, 2, 1]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   if (calculatedCheckDigit === 11 && givenCheckDigit === 0) {
     return Result.VALID;

--- a/src/lib/methods/method73.ts
+++ b/src/lib/methods/method73.ts
@@ -57,7 +57,7 @@ export default (number: string): Result => {
   const weightedDigits = weightDigitsRTL(digits, [2, 1, 2, 1, 2]);
   const crossSums = calculateCrossSums(weightedDigits);
   const sum = calculateSum(crossSums);
-  const calculatedCheckDigit = moduloDifference(sum, 7, 7);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 7, 7);
 
   if (calculatedCheckDigit === givenCheckDigit) {
     return Result.VALID;

--- a/src/lib/methods/method89.ts
+++ b/src/lib/methods/method89.ts
@@ -47,7 +47,7 @@ export default (number: string): Result => {
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const crossSums = calculateCrossSums(weightedDigits);
   const sum = calculateSum(crossSums);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/method91.ts
+++ b/src/lib/methods/method91.ts
@@ -34,7 +34,7 @@ const method91Core = (
 ): Result => {
   const weightedDigits = weightDigitsRTL(digits, weights);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 11, 11);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 11, 11);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };

--- a/src/lib/methods/methodA4.ts
+++ b/src/lib/methods/methodA4.ts
@@ -37,7 +37,7 @@ const variation2 = (number: string): Result => {
 
   const weightedDigits = weightDigitsRTL(digits, [2, 3, 4, 5, 6, 7]);
   const sum = calculateSum(weightedDigits);
-  const calculatedCheckDigit = moduloDifference(sum, 7, 7);
+  const { difference: calculatedCheckDigit } = moduloDifference(sum, 7, 7);
 
   return method06Result(givenCheckDigit, calculatedCheckDigit);
 };


### PR DESCRIPTION
Fixes #4

- adjusted `moduloDifference` to return remainder.
https://github.com/baumerdev/ibantools-germany/blob/82de93eae4548af23d0c2e4992791a572ff92fab/src/lib/helper.ts#L134-L141
- refactored consumers of `moduloDifference` to reflect changes
- changed behavior of method 16 to respect remainder instead of difference
- added test for special case
- increased patch version to .2