### PR TITLE
proposal to add esm module to dist target

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ all.
 The version numbers are based on [Semantic Versioning](https://semver.org/)
 with modifications.
 
-> 1.2205.3
+> 1.2205.4
 
 The first number representes the Major version. If this number increases there
 are updates that may not be backward compatible and you have to adjust your

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "pruefziffer",
     "pruefzifferberechnungsmethode"
   ],
-  "main": "./dist/cjs/main.js",
-  "module": "./dist/esm/main.js",
-  "types": "./dist/cjs/main.d.ts",
+  "main": "dist/cjs/main.js",
+  "module": "dist/esm/main.js",
+  "types": "./dist/types/main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/main.d.ts",
       "require": "./dist/cjs/main.js",
-      "import": "./dist/esm/main.js"
+      "import": "./dist/esm/main.js",
+      "default": "./dist/esm-wrapped/main.js"
     }
   },
   "files": [
@@ -43,7 +45,7 @@
     "test:coverage": "rimraf coverage && jest --coverage",
     "clean": "rimraf dist docs coverage package ibantools-germany*.tgz",
     "docs": "rimraf docs && typedoc --entryPoints src/main.ts --out docs/",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -b tsconfig.esm.json tsconfig.cjs.json tsconfig.types.json",
     "build:all": "rimraf dist && npm run build && npm run esm-wrapper && npm run esbuild",
     "esm-wrapper": "ts-node src/cli/esm-wrapper.ts",
     "esbuild": "esbuild src/browser.ts --bundle --minify --outfile=dist/build/browser.js",

--- a/src/cli/esm-wrapper.ts
+++ b/src/cli/esm-wrapper.ts
@@ -32,7 +32,7 @@ const esmWrapper = [
   ),
 ].join("\n");
 
-if (!fs.existsSync(`${__dirname}/../../dist/esm`)) {
-  fs.mkdirSync(`${__dirname}/../../dist/esm`, { recursive: true });
+if (!fs.existsSync(`${__dirname}/../../dist/esm-wrapped`)) {
+  fs.mkdirSync(`${__dirname}/../../dist/esm-wrapped`, { recursive: true });
 }
-fs.writeFileSync(`${__dirname}/../../dist/esm/main.js`, esmWrapper);
+fs.writeFileSync(`${__dirname}/../../dist/esm-wrapped/main.js`, esmWrapper);

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "commonjs"
+  },
+  "exclude": ["node_modules", "**/*.spec.ts", "src/browser*.ts", "src/cli/"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "ES2020"
+  },
   "exclude": ["node_modules", "**/*.spec.ts", "src/browser*.ts", "src/cli/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES6",
     "module": "CommonJS",
     "moduleResolution": "node",
-    "declaration": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationMap": false,
+    "declarationDir": "dist/types",
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["node_modules", "**/*.spec.ts", "src/browser*.ts", "src/cli/"]
+}


### PR DESCRIPTION
Fixes #15 

Just a proposal for the issue I've opened.

Not wrapping the cjs to create an esm build solves the issue as well.

I do not know your reason the wrap the cjs to create an esm module, 
and I'm not sure if defining it as default would still be a viable solution for the use case you intended.

Optionally you could extract and export the type declarations only once

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
