### PR TITLE
Fix ESM support with publint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.2402.2",
   "description": "IBAN Validator and Generator for German Bank Accounts",
   "author": "Markus Baumer <markus@baumer.dev>",
-  "repository": "https://github.com/baumerdev/ibantools-germany",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baumerdev/ibantools-germany.git"
+  },
   "homepage": "https://baumerdev.github.io/ibantools-germany/",
   "license": "AGPL",
   "keywords": [
@@ -21,20 +24,14 @@
     "pruefziffer",
     "pruefzifferberechnungsmethode"
   ],
-  "main": "./dist/cjs/main.js",
-  "module": "./dist/esm/main.js",
-  "types": "./dist/cjs/main.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/cjs/main.d.ts",
-        "default": "./dist/cjs/main.js"
-      },
-      "import": {
-        "types": "./dist/cjs/main.d.ts",
-        "default": "./dist/esm/main.js"
-      }
-    }
+      "types": "./dist/cjs/main.d.ts",
+      "import": "./dist/esm/main.mjs",
+      "require": "./dist/cjs/main.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/",

--- a/src/cli/esm-wrapper.ts
+++ b/src/cli/esm-wrapper.ts
@@ -35,4 +35,4 @@ const esmWrapper = [
 if (!fs.existsSync(`${__dirname}/../../dist/esm`)) {
   fs.mkdirSync(`${__dirname}/../../dist/esm`, { recursive: true });
 }
-fs.writeFileSync(`${__dirname}/../../dist/esm/main.js`, esmWrapper);
+fs.writeFileSync(`${__dirname}/../../dist/esm/main.mjs`, esmWrapper);


### PR DESCRIPTION
Hi @baumerdev, thank you for this package! 

I see that it has both CJS and ESM support (with an ESM wrapper). :+1:

I tried importing this package as ESM. But it still uses the CJS variant, because the `package.json` is not setup correctly.

There are online tools for that, where you can see the warnings:
- https://publint.dev/ibantools-germany@1.2402.2
- https://arethetypeswrong.github.io/?p=ibantools-germany%401.2402.2

> ./dist/esm/main.js is written in ESM, but is interpreted as CJS. Consider using the .mjs extension, e.g. ./dist/esm/main.mjs

In this PR, I updated `package.json` so it actually interprets ESM.

Before:

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/1a47f1ea-ba1b-4f32-9d3e-f50635a2c3c4">

After:

<img width="1413" alt="image" src="https://github.com/user-attachments/assets/8877ebf6-bc1e-4c2d-96ff-ab9b7d1cdfa7">

I verified that my fork now works in my ESM project.